### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/rssaini01/openseadragon-fabric-overlay/security/code-scanning/2](https://github.com/rssaini01/openseadragon-fabric-overlay/security/code-scanning/2)

To fix this issue, you should add an explicit `permissions` block to the workflow, specifying the minimum required access for the jobs. For workflows that run tests and publish to npm, typically only `contents: read` is required for most jobs unless any step needs to write to pull requests or repository (not the case here). The `publish-npm` job publishes to npm and does not require repository write access either. The recommended fix is to add the following at the root level (just below `name: Node.js Package`), so it applies to all jobs unless overridden: 

```yaml
permissions:
  contents: read
```

This limits the GITHUB_TOKEN permissions to read-only, adhering to the least privilege principle. Place this block after the `name` key in `.github/workflows/npm-publish-packages.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
