### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-packages.yml
+++ b/.github/workflows/npm-publish-packages.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/rssaini01/openseadragon-fabric-overlay/security/code-scanning/1](https://github.com/rssaini01/openseadragon-fabric-overlay/security/code-scanning/1)

The correct fix is to set an explicit `permissions` block at the top (global) level of your workflow file to restrict the GITHUB_TOKEN to only the rights required by all jobs. For this workflow, the typical minimal requirement is `contents: read` for checking out code and installing dependencies, and, if publishing to GitHub Packages (not to npmjs.org), you might need `packages: write`; but in this specific workflow all publishing is performed via an explicit `NPM_TOKEN` secret, and there is no interaction with GitHub Packages, so `contents: read` is probably sufficient. If a job needs higher permissions, you can grant them at the job level.  
The change should be made near the top of the `.github/workflows/npm-publish-packages.yml` file, directly after the `name:` field and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
